### PR TITLE
Split INVITE and non-INVITE transaction types

### DIFF
--- a/sip/invite_client_transaction.go
+++ b/sip/invite_client_transaction.go
@@ -1,0 +1,45 @@
+package sip
+
+type inviteClientTransactionState int
+
+const (
+	inviteClientTransactionStateCalling inviteClientTransactionState = iota
+	inviteClientTransactionStateProceeding
+	inviteClientTransactionStateCompleted
+	inviteClientTransactionStateTerminated
+)
+
+type inviteClientTransaction struct {
+	*transactionData
+	state      inviteClientTransactionState
+	serverTxID string
+}
+
+func newInviteClientTransaction(data *transactionData, serverTxID string) clientTransaction {
+	return &inviteClientTransaction{
+		transactionData: data,
+		state:           inviteClientTransactionStateCalling,
+		serverTxID:      serverTxID,
+	}
+}
+
+func (t *inviteClientTransaction) data() *transactionData {
+	return t.transactionData
+}
+
+func (t *inviteClientTransaction) onReceiveResponse(status int) bool {
+	if status < 200 {
+		t.state = inviteClientTransactionStateProceeding
+		return false
+	}
+	if status < 300 {
+		t.state = inviteClientTransactionStateCompleted
+	} else {
+		t.state = inviteClientTransactionStateTerminated
+	}
+	return true
+}
+
+func (t *inviteClientTransaction) serverID() string {
+	return t.serverTxID
+}

--- a/sip/invite_server_transaction.go
+++ b/sip/invite_server_transaction.go
@@ -1,0 +1,37 @@
+package sip
+
+type inviteServerTransactionState int
+
+const (
+	inviteServerTransactionStateProceeding inviteServerTransactionState = iota
+	inviteServerTransactionStateCompleted
+	inviteServerTransactionStateTerminated
+)
+
+type inviteServerTransaction struct {
+	*transactionData
+	state inviteServerTransactionState
+}
+
+func newInviteServerTransaction(data *transactionData) serverTransaction {
+	return &inviteServerTransaction{
+		transactionData: data,
+		state:           inviteServerTransactionStateProceeding,
+	}
+}
+
+func (t *inviteServerTransaction) data() *transactionData {
+	return t.transactionData
+}
+
+func (t *inviteServerTransaction) onSendResponse(status int) {
+	if status < 200 {
+		t.state = inviteServerTransactionStateProceeding
+		return
+	}
+	if status < 300 {
+		t.state = inviteServerTransactionStateTerminated
+		return
+	}
+	t.state = inviteServerTransactionStateCompleted
+}

--- a/sip/non_invite_client_transaction.go
+++ b/sip/non_invite_client_transaction.go
@@ -1,0 +1,40 @@
+package sip
+
+type nonInviteClientTransactionState int
+
+const (
+	nonInviteClientTransactionStateTrying nonInviteClientTransactionState = iota
+	nonInviteClientTransactionStateProceeding
+	nonInviteClientTransactionStateCompleted
+)
+
+type nonInviteClientTransaction struct {
+	*transactionData
+	state      nonInviteClientTransactionState
+	serverTxID string
+}
+
+func newNonInviteClientTransaction(data *transactionData, serverTxID string) clientTransaction {
+	return &nonInviteClientTransaction{
+		transactionData: data,
+		state:           nonInviteClientTransactionStateTrying,
+		serverTxID:      serverTxID,
+	}
+}
+
+func (t *nonInviteClientTransaction) data() *transactionData {
+	return t.transactionData
+}
+
+func (t *nonInviteClientTransaction) onReceiveResponse(status int) bool {
+	if status < 200 {
+		t.state = nonInviteClientTransactionStateProceeding
+		return false
+	}
+	t.state = nonInviteClientTransactionStateCompleted
+	return true
+}
+
+func (t *nonInviteClientTransaction) serverID() string {
+	return t.serverTxID
+}

--- a/sip/non_invite_server_transaction.go
+++ b/sip/non_invite_server_transaction.go
@@ -1,0 +1,34 @@
+package sip
+
+type nonInviteServerTransactionState int
+
+const (
+	nonInviteServerTransactionStateTrying nonInviteServerTransactionState = iota
+	nonInviteServerTransactionStateProceeding
+	nonInviteServerTransactionStateCompleted
+	nonInviteServerTransactionStateTerminated
+)
+
+type nonInviteServerTransaction struct {
+	*transactionData
+	state nonInviteServerTransactionState
+}
+
+func newNonInviteServerTransaction(data *transactionData) serverTransaction {
+	return &nonInviteServerTransaction{
+		transactionData: data,
+		state:           nonInviteServerTransactionStateTrying,
+	}
+}
+
+func (t *nonInviteServerTransaction) data() *transactionData {
+	return t.transactionData
+}
+
+func (t *nonInviteServerTransaction) onSendResponse(status int) {
+	if status < 200 {
+		t.state = nonInviteServerTransactionStateProceeding
+		return
+	}
+	t.state = nonInviteServerTransactionStateTerminated
+}


### PR DESCRIPTION
## Summary
- add dedicated INVITE and non-INVITE server/client transaction implementations with their own state enums
- refactor the transaction layer to create the appropriate transaction type per method while keeping shared data handling

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_b_68ce9a2b73bc8323a466128721988603